### PR TITLE
[WIP] Implement WebFontLoader to load Roboto fonts before drawing canvas

### DIFF
--- a/resources/public/css/main.css
+++ b/resources/public/css/main.css
@@ -1,6 +1,3 @@
-@import url(http://fonts.googleapis.com/css?family=Roboto:100,300,400,700);
-@import url(http://fonts.googleapis.com/css?family=Open+Sans);
-
 body {
   background: #1a1a1a;
   margin: 0;

--- a/resources/public/index.html
+++ b/resources/public/index.html
@@ -5,6 +5,7 @@
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="css/keys.css" type="text/css">
     <link rel="stylesheet" href="css/main.css" type="text/css">
+    <script src="//ajax.googleapis.com/ajax/libs/webfont/1.5.10/webfont.js"></script>
   </head>
   <body>
     <img id="jsLogo" src="js.svg">

--- a/resources/public/index_release.html
+++ b/resources/public/index_release.html
@@ -4,6 +4,7 @@
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
     <link rel="stylesheet" href="css/keys.css" type="text/css">
     <link rel="stylesheet" href="css/main.css" type="text/css">
+    <script src="//ajax.googleapis.com/ajax/libs/webfont/1.5.10/webfont.js"></script>
   </head>
   <body>
     <img id="jsLogo" src="js.svg">


### PR DESCRIPTION
This pull request resolves an issue related to loading the Roboto font from Google after the title slide is initially drawn. For me, this causes it to be rendered in a sans-serif font for the first frame.

My solution is to use [WebFontLoader](https://github.com/typekit/webfontloader) to load the fonts and initiate drawing on the canvas as the successful callback method.

The initial commit (21f446a) is fairly naive but just an example that this does alleviate the issue. I'll finish this and tidy up the branch after some feedback.

(First PR!)

![Font Error](http://i.imgur.com/8csRmbz.png?1)
